### PR TITLE
Fix snpEff wrapper to correctly handle -canon and -cancer inputs.

### DIFF
--- a/scripts/snpEff
+++ b/scripts/snpEff
@@ -42,7 +42,7 @@ done
 if [ "$jvm_mem_opts" == "" ]; then
     jvm_mem_opts="$default_jvm_mem_opts"
 fi
-if [[ "$pass_args" != "" && "$pass_args" =~ "-c " ]]; then
+if [[ "$pass_args" != "" && ! "$pass_args" =~ "-c " ]]; then
     pass_args="$pass_args -c ${jardir}/snpEff.config"
 fi
 


### PR DESCRIPTION
Pablo;
Sorry about the `-c` bug in the wrapper script. This is a fix via @mjafin that avoids the issue with `-c` detection overlapping with `-canon`  and `-cancer` arguments. Thanks much.

chapmanb/bcbio-nextgen#441
