### PR TITLE
use system tmpdir when downloading

### DIFF
--- a/src/main/java/ca/mcgill/mcb/pcingola/snpEffect/commandLine/SnpEffCmdDownload.java
+++ b/src/main/java/ca/mcgill/mcb/pcingola/snpEffect/commandLine/SnpEffCmdDownload.java
@@ -63,7 +63,7 @@ public class SnpEffCmdDownload extends SnpEff {
 		if (verbose) Timer.showStdErr("Downloading database for '" + genomeVer + "'");
 
 		URL url = config.downloadUrl(genomeVer);
-		String localFile = Download.urlBaseName(url.toString());
+		String localFile = System.getProperty("java.io.tmpdir") + "/" + Download.urlBaseName(url.toString());
 
 		// Download and UnZIP
 		Download download = new Download();


### PR DESCRIPTION
I think it makes sense to use the system tmpdir when fetching files, rather than placing them in the current dir. 

Oneliner ;) 
