### PR TITLE
options to output both csv and html

### DIFF
--- a/src/main/java/ca/mcgill/mcb/pcingola/snpEffect/commandLine/SnpEffCmdEff.java
+++ b/src/main/java/ca/mcgill/mcb/pcingola/snpEffect/commandLine/SnpEffCmdEff.java
@@ -72,8 +72,6 @@ public class SnpEffCmdEff extends SnpEff implements VcfAnnotator {
 	boolean anyCancerSample;
 	boolean cancer = false; // Perform cancer comparisons
 	boolean chromoPlots = true; // Create mutations by chromosome plots?
-	//boolean createCsvSummary = false; // Use a CSV as output summary
-	//boolean createSummary = true; // Create summary output file
 	boolean createSummaryCSV = false;
 	boolean createSummaryHTML = true;
 	boolean lossOfFunction = true; // Create loss of function LOF tag?
@@ -88,7 +86,6 @@ public class SnpEffCmdEff extends SnpEff implements VcfAnnotator {
 	String cancerSamples = null;
 	String chrStr = "";
 	String inputFile = ""; // Input file
-	//String summaryFile; // Summary output file
 	String summaryFileCSV;
 	String summaryFileHTML;
 	String summaryGenesFile; // Gene table file


### PR DESCRIPTION
We're interested in being able to output both csv and html formats for SnpEff.  So, I've introduced options to allow one or the other or both, i.e., -htmlStats and -csvStats. Example usage,
java -jar snpEff.jar -c asnpeffconfigfile.config -o vcf -v -csvStats test.csv -htmlStats test.html GRCh37.75 somedata_snv.vcf