### PR TITLE
make VcfEntry.java supports vcf format 4.2

### DIFF
--- a/src/main/java/org/snpeff/vcf/VcfEntry.java
+++ b/src/main/java/org/snpeff/vcf/VcfEntry.java
@@ -927,7 +927,7 @@ public class VcfEntry extends Marker implements Iterable<VcfGenotype> {
 
 		// SNP
 		if (altsStr.length() == 1) {
-			if (altsStr.equals("A") || altsStr.equals("C") || altsStr.equals("G") || altsStr.equals("T") || altsStr.equals(".")) {
+			if (altsStr.equals("A") || altsStr.equals("C") || altsStr.equals("G") || altsStr.equals("T") || altsStr.equals("*")) {
 				alts = new String[1];
 				alts[0] = altsStr;
 			} else if (altsStr.equals("N")) { // aNy base


### PR DESCRIPTION
from vcf fromat pdf:
ALT - alternate base(s): Comma separated list of alternate non-reference alleles called on at least one of the
samples. Options are base Strings made up of the bases A,C,G,T,N,*, (case insensitive) or an angle-bracketed
ID String (“<ID>”) or a breakend replacement string as described in the section on breakends. The ‘*’ allele
is reserved to indicate that the allele is missing due to a upstream deletion. If there are no alternative alleles,
then the missing value should be used. Tools processing VCF files are not required to preserve case in the
allele String, except for IDs, which are case sensitive. (String; no whitespace, commas, or angle-brackets are
permitted in the ID String itself)

the code was accepting "." which is not a defined REF allele but not the official "*" allele for deletion