### PR TITLE
Fix bug preventing reading of dbNSFP_sort.pl cmdline args

### DIFF
--- a/scripts_build/dbNSFP_sort.pl
+++ b/scripts_build/dbNSFP_sort.pl
@@ -22,7 +22,7 @@ $replace = 0;
 $showTitle = 1;
 
 # Two arguments? Use them as columns for chr and pos respectively
-if( $#ARGV > 1 ) {
+if( $#ARGV > 0 ) {
 	$chrCol = $ARGV[0];
 	$posCol = $ARGV[1];
 	$showTitle = 0;


### PR DESCRIPTION
Because the number of arguments given on the command line is `$#ARGV + 1`, the script doesn't currently use/parse the command line arguments (unless 3 arguments are provided).