### PR TITLE
Add necessary interfaces to run SnpEff as a library

### DIFF
--- a/src/main/java/org/snpeff/SnpEff.java
+++ b/src/main/java/org/snpeff/SnpEff.java
@@ -357,7 +357,7 @@ public class SnpEff implements CommandLine {
 	/**
 	 * Copy values to a new command
 	 */
-	void copyValues(SnpEff cmd) {
+	public void copyValues(SnpEff cmd) {
 		cmd.canonical = canonical;
 		cmd.canonicalFile = canonicalFile;
 		cmd.configFile = configFile;

--- a/src/main/java/org/snpeff/outputFormatter/OutputFormatter.java
+++ b/src/main/java/org/snpeff/outputFormatter/OutputFormatter.java
@@ -44,6 +44,11 @@ public abstract class OutputFormatter {
 		variantEffects = new ArrayList<VariantEffect>();
 	}
 
+	public void setOutputWriter(BufferedWriter out) {
+		this.out = out;
+	}
+
+
 	/**
 	 * Add effects to list
 	 */

--- a/src/main/java/org/snpeff/snpEffect/commandLine/SnpEffCmdEff.java
+++ b/src/main/java/org/snpeff/snpEffect/commandLine/SnpEffCmdEff.java
@@ -117,6 +117,10 @@ public class SnpEffCmdEff extends SnpEff implements VcfAnnotator {
 		summaryGenesFile = DEFAULT_SUMMARY_GENES_FILE;
 	}
 
+	public void setOutputFormatter(OutputFormatter outputFormatter) {
+		this.outputFormatter = outputFormatter;
+	}
+
 	@Override
 	public boolean addHeaders(VcfFileIterator vcfFile) {
 		// This is done by VcfOutputFormatter, so there is nothing to do here.
@@ -162,15 +166,15 @@ public class SnpEffCmdEff extends SnpEff implements VcfAnnotator {
 	public boolean annotate(VcfEntry vcfEntry) {
 		boolean printed = false;
 		boolean filteredOut = false;
-		VcfFileIterator vcfFile = vcfEntry.getVcfFileIterator();
 
 		try {
 			countInputLines++;
 			countVcfEntries++;
 
 			// Find if there is a pedigree and if it has any 'derived' entry
-			if (vcfFile.isHeadeSection()) {
-				if (cancer) {
+			if (cancer) {
+				VcfFileIterator vcfFile = vcfEntry.getVcfFileIterator();
+                if (vcfFile.isHeadeSection()) {
 					pedigree = readPedigree(vcfFile);
 					anyCancerSample = pedigree.anyDerived();
 				}
@@ -185,9 +189,6 @@ public class SnpEffCmdEff extends SnpEff implements VcfAnnotator {
 				filteredOut = true;
 				return false;
 			}
-
-			// Create new 'section'
-			outputFormatter.startSection(vcfEntry);
 
 			// ---
 			// Analyze all changes in this VCF entry
@@ -214,7 +215,7 @@ public class SnpEffCmdEff extends SnpEff implements VcfAnnotator {
 			printed = true;
 		} catch (Throwable t) {
 			totalErrs++;
-			error(t, "Error while processing VCF entry (line " + vcfFile.getLineNum() + ") :\n\t" + vcfEntry + "\n"
+			error(t, "Error while processing VCF entry :\n\t" + vcfEntry + "\n"
 					+ t);
 		} finally {
 			if (!printed && !filteredOut)

--- a/src/main/java/org/snpeff/snpEffect/commandLine/SnpEffCmdEff.java
+++ b/src/main/java/org/snpeff/snpEffect/commandLine/SnpEffCmdEff.java
@@ -1,10 +1,6 @@
 package org.snpeff.snpEffect.commandLine;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
+import java.io.*;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -117,8 +113,8 @@ public class SnpEffCmdEff extends SnpEff implements VcfAnnotator {
 		summaryGenesFile = DEFAULT_SUMMARY_GENES_FILE;
 	}
 
-	public void setOutputFormatter(OutputFormatter outputFormatter) {
-		this.outputFormatter = outputFormatter;
+	public void setOutputWriter(BufferedWriter writer) {
+		this.outputFormatter.setOutputWriter(writer);
 	}
 
 	@Override
@@ -189,6 +185,9 @@ public class SnpEffCmdEff extends SnpEff implements VcfAnnotator {
 				filteredOut = true;
 				return false;
 			}
+
+			// Create new 'section'
+			outputFormatter.startSection(vcfEntry);
 
 			// ---
 			// Analyze all changes in this VCF entry
@@ -319,7 +318,7 @@ public class SnpEffCmdEff extends SnpEff implements VcfAnnotator {
 	/**
 	 * Calculate the effect of variants and show results
 	 */
-	protected void annotateInit(String outputFile) {
+	public void annotateInit(String outputFile) {
 		snpEffectPredictor = config.getSnpEffectPredictor();
 
 		// Reset all counters
@@ -491,9 +490,13 @@ public class SnpEffCmdEff extends SnpEff implements VcfAnnotator {
 	 * Iterate on all inputs (VCF) and calculate effects. Note: This is used only on
 	 * input format VCF, which has a different iteration modality
 	 */
+
 	VcfFileIterator annotateVcf(String inputFile) {
+		return annotateVcf(new VcfFileIterator(inputFile, genome));
+	}
+
+	public VcfFileIterator annotateVcf(VcfFileIterator vcfFile) {
 		// Open VCF file
-		VcfFileIterator vcfFile = new VcfFileIterator(inputFile, config.getGenome());
 		vcfFile.setDebug(debug);
 
 		// Iterate over VCF entries


### PR DESCRIPTION
- Add method to annotate a `VcfFileIterator` instead of a file
- Expose methods to set the output writer for an annotation run
- Expose convenience method to copy configuration between annotators