### PR TITLE
Fixes to work with Material 5.x version

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,17 +14,17 @@ theme:
   palette:
       primary: 'indigo'
       accent: 'indigo'
-  feature:
-      tabs: true
+  features:
+      - tabs
 markdown_extensions:
   - admonition
   - attr_list
 
 extra:
   social:
-    - type: 'linkedin'
+    - icon: fontawesome/brands/linkedin
       link: 'http://www.linkedin.com/in/pablocingolani'
-    - type: 'github'
+    - icon: fontawesome/brands/github-alt
       link: 'https://github.com/pcingola/SnpEff'
 
 nav:

--- a/readme.mkdocs.md
+++ b/readme.mkdocs.md
@@ -1,10 +1,9 @@
 # Installation of mkdocs
 
-To build docs you need mkdocs and mkdocs-material theme installed:
+To build docs you need mkdocs-material theme installed (mkdocs dependencies is included in mkdocs-material now):
 <https://www.mkdocs.org/#installing-mkdocs>
 
-    pip install mkdocs
-    pip install mkdocs-material
+    pip install mkdocs-material==5.2
 
 # Building docs
 


### PR DESCRIPTION
### Documentation

mkdocs.yml keys for social links icons and features are changed for Material 5.x version:
https://squidfunk.github.io/mkdocs-material/releases/5/#how-to-upgrade

Don't need to install `mkdocs` separately, as well, it will be installed along with `mkdocs-material`.