### PR TITLE
Fixed typos from "Ouput" to "Output" in code and documentation

### DIFF
--- a/docs/snpeff/commandline/index.html
+++ b/docs/snpeff/commandline/index.html
@@ -1559,7 +1559,7 @@ Options:
     -download                       : Download reference genome if not available. Default: true
     -i &lt;format&gt;                     : Input format [ vcf, bed ]. Default: VCF.
     -fileList                       : Input actually contains a list of files to process.
-    -o &lt;format&gt;                     : Ouput format [ vcf, gatk, bed, bedAnn ]. Default: VCF.
+    -o &lt;format&gt;                     : Output format [ vcf, gatk, bed, bedAnn ]. Default: VCF.
     -s , -stats                     : Name of stats file (summary). Default is &#39;snpEff_summary.html&#39;
     -noStats                        : Do not create stats (summary) file
     -csvStats                       : Create CSV summary file instead of HTML

--- a/src/docs/snpeff/commandline.md
+++ b/src/docs/snpeff/commandline.md
@@ -105,7 +105,7 @@ Options:
 	-download                       : Download reference genome if not available. Default: true
 	-i <format>                     : Input format [ vcf, bed ]. Default: VCF.
 	-fileList                       : Input actually contains a list of files to process.
-	-o <format>                     : Ouput format [ vcf, gatk, bed, bedAnn ]. Default: VCF.
+	-o <format>                     : Output format [ vcf, gatk, bed, bedAnn ]. Default: VCF.
 	-s , -stats                     : Name of stats file (summary). Default is 'snpEff_summary.html'
 	-noStats                        : Do not create stats (summary) file
 	-csvStats                       : Create CSV summary file instead of HTML

--- a/src/main/java/org/snpeff/osCmd/OsCmdRunner.java
+++ b/src/main/java/org/snpeff/osCmd/OsCmdRunner.java
@@ -16,7 +16,7 @@ public class OsCmdRunner extends Thread {
 	long defaultWaitTime = 100; // Default time to use in 'wait' calls when initialting the command
 	long defaultLoopWaitTime = 1000; // Default time to use in 'wait' calls
 	String jobId = "";
-	String head = ""; // Ouput's head
+	String head = ""; // Output's head
 	String headStderr = ""; // Stderr's head
 	String error; // Latest error message
 	String stdout = "", stderr = "";

--- a/src/main/java/org/snpeff/snpEffect/commandLine/SnpEffCmdEff.java
+++ b/src/main/java/org/snpeff/snpEffect/commandLine/SnpEffCmdEff.java
@@ -1018,7 +1018,7 @@ public class SnpEffCmdEff extends SnpEff implements VcfAnnotator {
 		System.err.println("\t-download                       : Download reference genome if not available. Default: " + download);
 		System.err.println("\t-i <format>                     : Input format [ vcf, bed ]. Default: VCF.");
 		System.err.println("\t-fileList                       : Input actually contains a list of files to process.");
-		System.err.println("\t-o <format>                     : Ouput format [ vcf, gatk, bed, bedAnn ]. Default: VCF.");
+		System.err.println("\t-o <format>                     : Output format [ vcf, gatk, bed, bedAnn ]. Default: VCF.");
 		System.err.println("\t-s , -stats, -htmlStats         : Create HTML summary file.  Default is '" + DEFAULT_SUMMARY_HTML_FILE + "'");
 		System.err.println("\t-noStats                        : Do not create stats (summary) file");
 		System.err.println("\nResults filter options:");


### PR DESCRIPTION
This fixes a minor typo that appears in four places in the code.  It changes "Ouput" to "Output".  

This typo occurs in the command line help, the markdown documentation of the command line in both HTML and Markdown, and in a comment in the OsCmdRunner.java.  